### PR TITLE
remove `progress-bar-striped` class

### DIFF
--- a/src/app/home/alarm.tpl.html
+++ b/src/app/home/alarm.tpl.html
@@ -98,7 +98,7 @@
                         </div>
                     </timer>
                     <div class="progress" ng-hide="displayProgressBar === 100">
-                        <div class="progress-bar progress-bar-success progress-bar-striped {{displayProgressActive}}" role="progressbar" aria-valuenow="{{ displayProgressBar }}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2.3em; width:{{ displayProgressBar }}%;">
+                        <div class="progress-bar progress-bar-success {{displayProgressActive}}" role="progressbar" aria-valuenow="{{ displayProgressBar }}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2.3em; width:{{ displayProgressBar }}%;">
                             {{ displayProgressBar }}%
                         </div>
                     </div>


### PR DESCRIPTION
This class use an CSS animation that consume 100% of 1 CPU core (annoying if you try to sleep next to your noisy laptop)